### PR TITLE
Admin dashboard invoices

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -2,5 +2,6 @@ class AdminController < ApplicationController
 
   def index
     @customers = Customer.all
+    @invoices = Invoice.all
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -6,10 +6,10 @@ class Invoice < ApplicationRecord
 
   validates :status, presence: true
   
-  enum status: ["In Progress", "Cancelled", "Completed"]
+  enum status: ["in progress", "cancelled", "completed"]
 
   # class method for checking status of invoice
-  def self.incomplete_invoices
+  def self.invoices_with_unshipped_items
     Invoice.select("invoices.*").joins(:invoice_items).where("invoice_items.status != 2")
   end
 

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -1,8 +1,16 @@
 class Invoice < ApplicationRecord
   belongs_to :customer
   has_many :transactions, dependent: :destroy
+  has_many :invoice_items, dependent: :destroy
+  has_many :items, through: :invoice_items
 
   validates :status, presence: true
   
   enum status: ["In Progress", "Cancelled", "Completed"]
+
+  # class method for checking status of invoice
+  def self.incomplete_invoices
+    Invoice.select("invoices.*").joins(:invoice_items).where("invoice_items.status != 2")
+  end
+
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -6,5 +6,5 @@ class InvoiceItem < ApplicationRecord
   validates :unit_price, presence: true
   validates :status, presence: true
   
-  enum status: ["Pending", "Packaged", "Shipped"]
+  enum status: ["pending", "packaged", "shipped"]
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,6 @@
 class Item < ApplicationRecord
   belongs_to :merchant
+  has_many :invoice_items, dependent: :destroy
 
   validates :name, presence: true
   validates :description, presence: true

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,5 +1,7 @@
 class Merchant < ApplicationRecord
   has_many :items
+  has_many :invoice_items, through: :items
+  has_many :invoices, through: :invoice_items
 
   validates :name, presence: true
 end

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -4,12 +4,22 @@
 <%= link_to "Invoices", "/admin/invoices" %>
 
 <div id = "top_customers">
+<h3>Top Customers</h3>
   <ol>
   <% @customers.top_five_customers.each do |customer| %>
-      <div id = "top_customer<%= customer.id %>">
-        <li><p><%= customer.first_name %> <%= customer.last_name %> - <%= customer.successful_transactions_count%> purchases</p>
-        </li>
-      </div>
+    <div id = "top_customer<%= customer.id %>">
+      <li><p><%= customer.first_name %> <%= customer.last_name %> - <%= customer.successful_transactions_count%> purchases</p>
+      </li>
+    </div>
   <% end %>
   </ol>
 </div>
+
+<section class="incomplete_invoices">
+<h3>Incomplete Invoices</h3>
+  <% @invoices.invoices_with_unshipped_items.each do |invoice| %>
+    <div id="invoice_<%= invoice.id %>">
+      <p><%= link_to "Invoice ##{invoice.id} - #{invoice.created_at}", "/admin/invoices/#{invoice.id}", data: {turbo: false} %></p>
+    </div>
+  <% end %>
+</section>

--- a/spec/factories/invoice_items.rb
+++ b/spec/factories/invoice_items.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :invoice_item do
-    item { nil }
-    invoice { nil }
-    quantity { 1 }
-    unit_price { 1 }
+    item { association :item }
+    invoice { association :invoice }
+    quantity { Faker::Number.number(digits: 1) }
+    unit_price {  }
     status { 1 }
   end
 end

--- a/spec/factories/invoice_items.rb
+++ b/spec/factories/invoice_items.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     item { association :item }
     invoice { association :invoice }
     quantity { Faker::Number.number(digits: 1) }
-    unit_price {  }
+    unit_price { 1 }
     status { 1 }
   end
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :item do
     name { Faker::Commerce.product_name }
-    description { Faker::Commerce.product_description }
-    unit_price { Faker::Commerce.price(100..99999).to_i }
+    description { Faker::Commerce.material }
+    unit_price { Faker::Commerce.price(range: 100..99999).to_i }
     merchant { association :merchant }
   end
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :item do
-    name { "MyString" }
-    description { "MyString" }
-    unit_price { 1 }
-    merchant { nil }
+    name { Faker::Commerce.product_name }
+    description { Faker::Commerce.product_description }
+    unit_price { Faker::Commerce.price(100..99999).to_i }
+    merchant { association :merchant }
   end
 end

--- a/spec/factories/merchants.rb
+++ b/spec/factories/merchants.rb
@@ -1,5 +1,9 @@
 FactoryBot.define do
   factory :merchant do
-    name { "MyString" }
+    name { Faker::Company.name }
+
+    after :create do |merchant|
+      create_list :item, 5, merchant: merchant
+    end
   end
 end

--- a/spec/features/admin/index_spec.rb
+++ b/spec/features/admin/index_spec.rb
@@ -62,7 +62,6 @@ RSpec.describe 'Admin Dashboard (Index)', type: :feature do
       @invoice_item_3 = InvoiceItem.create!(item_id: @item_3.id, invoice_id: @invoice_3.id, quantity: 1, unit_price: 1300, status: 1)
       @invoice_item_4 = InvoiceItem.create!(item_id: @item_4.id, invoice_id: @invoice_4.id, quantity: 1, unit_price: 1300, status: 2)
       @invoice_item_5 = InvoiceItem.create!(item_id: @item_5.id, invoice_id: @invoice_5.id, quantity: 1, unit_price: 1300, status: 2)
-
     end
 
     #User Story 19
@@ -99,6 +98,7 @@ RSpec.describe 'Admin Dashboard (Index)', type: :feature do
       visit admin_index_path
 
       within "#top_customers" do
+        expect(page).to have_content("Top Customers")
         # Then I see the names of the top 5 customers
         within "#top_customer#{@customer_1.id}" do
           # who have conducted the largest number of successful transactions
@@ -135,26 +135,26 @@ RSpec.describe 'Admin Dashboard (Index)', type: :feature do
       # As an admin, When I visit the admin dashboard (/admin)
       visit admin_index_path
       # Then I see a section for "Incomplete Invoices"
-      expect(page).to have_content("Incomplete Invoices")
-      within '#incomplete-invoices' do
+      within ".incomplete_invoices" do
+        expect(page).to have_content("Incomplete Invoices")
       # In that section I see a list of the ids of all invoices
       # That have items that have not yet been shipped
       # And each invoice id links to that invoice's admin show page
-        within "#invoice-#{@invoice_1.id}" do
+        within "#invoice_#{@invoice_1.id}" do
           expect(page).to have_content("Invoice ##{@invoice_1.id} - #{@invoice_1.created_at}")
-          expect(page).to have_link("/admin/invoices/#{@invoice_1.id}")
+          expect(page).to have_link(:href => "/admin/invoices/#{@invoice_1.id}")
         end
 
-        within "#invoice-#{@invoice_2.id}" do
+        within "#invoice_#{@invoice_2.id}" do
           expect(page).to have_content("Invoice ##{@invoice_2.id} - #{@invoice_2.created_at}")
-          expect(page).to have_link("/admin/invoices/#{@invoice_2.id}")
+          expect(page).to have_link(:href => "/admin/invoices/#{@invoice_2.id}")
         end
 
-        within "#invoice-#{@invoice_3.id}" do
+        within "#invoice_#{@invoice_3.id}" do
           expect(page).to have_content("Invoice ##{@invoice_3.id} - #{@invoice_3.created_at}")
-          expect(page).to have_link("/admin/invoices/#{@invoice_3.id}")
+          expect(page).to have_link(:href => "/admin/invoices/#{@invoice_3.id}")
         end
-        
+
         expect(page).not_to have_content(@invoice_4.id)
         expect(page).not_to have_content(@invoice_5.id)
       end

--- a/spec/features/admin/index_spec.rb
+++ b/spec/features/admin/index_spec.rb
@@ -9,6 +9,60 @@ RSpec.describe 'Admin Dashboard (Index)', type: :feature do
       @customer_3 = @customers[2]
       @customer_4 = @customers[3]
       @customer_5 = @customers[4]
+      @customer_6 = @customers[5]
+      @customer_7 = @customers[6]
+      @customer_8 = @customers[7]
+      @customer_9 = @customers[8]
+      @customer_10 = @customers[9]
+      @invoice_1 = @customer_1.invoices[0]
+      @invoice_2 = @customer_1.invoices[1]
+      @invoice_3 = @customer_1.invoices[2]
+      @invoice_4 = @customer_1.invoices[3]
+      @invoice_5 = @customer_1.invoices[4]
+      @invoice_6 = @customer_2.invoices[0]
+      @invoice_7 = @customer_2.invoices[1]
+      @invoice_8 = @customer_2.invoices[2]
+      @invoice_9 = @customer_2.invoices[3]
+      @invoice_10 = @customer_2.invoices[4]
+      @invoice_11 = @customer_3.invoices[0]
+      @invoice_12 = @customer_3.invoices[1]
+      @invoice_13 = @customer_3.invoices[2]
+      @invoice_14 = @customer_3.invoices[3]
+      @invoice_15 = @customer_3.invoices[4]
+      @invoice_16 = @customer_4.invoices[0]
+      @invoice_17 = @customer_4.invoices[1]
+      @invoice_18 = @customer_4.invoices[2]
+      @invoice_19 = @customer_4.invoices[3]
+      @invoice_20 = @customer_4.invoices[4]
+      @invoice_21 = @customer_5.invoices[0]
+      @invoice_22 = @customer_5.invoices[1]
+      @invoice_23 = @customer_5.invoices[2]
+      @invoice_24 = @customer_5.invoices[3]
+      @invoice_25 = @customer_5.invoices[4]
+
+      @merchants = create_list(:merchant, 10)
+      @merchant_1 = @merchants[0]
+      @merchant_2 = @merchants[1]
+      @merchant_3 = @merchants[2]
+      @merchant_4 = @merchants[3]
+      @merchant_5 = @merchants[4]
+      @merchant_6 = @merchants[5]
+      @merchant_7 = @merchants[6]
+      @merchant_8 = @merchants[7]
+      @merchant_9 = @merchants[8]
+      @merchant_10 = @merchants[9]
+      @item_1 = @merchant_1.items[0]
+      @item_2 = @merchant_1.items[1]
+      @item_3 = @merchant_1.items[2]
+      @item_4 = @merchant_1.items[3]
+      @item_5 = @merchant_1.items[4]
+
+      @invoice_item_1 = InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_1.id, quantity: 1, unit_price: 1300, status: 0)
+      @invoice_item_2 = InvoiceItem.create!(item_id: @item_2.id, invoice_id: @invoice_2.id, quantity: 1, unit_price: 1300, status: 0)
+      @invoice_item_3 = InvoiceItem.create!(item_id: @item_3.id, invoice_id: @invoice_3.id, quantity: 1, unit_price: 1300, status: 1)
+      @invoice_item_4 = InvoiceItem.create!(item_id: @item_4.id, invoice_id: @invoice_4.id, quantity: 1, unit_price: 1300, status: 2)
+      @invoice_item_5 = InvoiceItem.create!(item_id: @item_5.id, invoice_id: @invoice_5.id, quantity: 1, unit_price: 1300, status: 2)
+
     end
 
     #User Story 19
@@ -72,6 +126,37 @@ RSpec.describe 'Admin Dashboard (Index)', type: :feature do
           expect(page).to have_content("#{@customer_5.first_name} #{@customer_5.last_name}")
           expect(page).to have_content("15 purchases")
         end
+      end
+    end
+
+
+    # User Story 22. Admin Dashboard Incomplete Invoices
+    it 'has a section that shows all incomplete invoices with their invoice ids and links to each invoices admin-show page' do
+      # As an admin, When I visit the admin dashboard (/admin)
+      visit admin_index_path
+      # Then I see a section for "Incomplete Invoices"
+      expect(page).to have_content("Incomplete Invoices")
+      within '#incomplete-invoices' do
+      # In that section I see a list of the ids of all invoices
+      # That have items that have not yet been shipped
+      # And each invoice id links to that invoice's admin show page
+        within "#invoice-#{@invoice_1.id}" do
+          expect(page).to have_content("Invoice ##{@invoice_1.id} - #{@invoice_1.created_at}")
+          expect(page).to have_link("/admin/invoices/#{@invoice_1.id}")
+        end
+
+        within "#invoice-#{@invoice_2.id}" do
+          expect(page).to have_content("Invoice ##{@invoice_2.id} - #{@invoice_2.created_at}")
+          expect(page).to have_link("/admin/invoices/#{@invoice_2.id}")
+        end
+
+        within "#invoice-#{@invoice_3.id}" do
+          expect(page).to have_content("Invoice ##{@invoice_3.id} - #{@invoice_3.created_at}")
+          expect(page).to have_link("/admin/invoices/#{@invoice_3.id}")
+        end
+        
+        expect(page).not_to have_content(@invoice_4.id)
+        expect(page).not_to have_content(@invoice_5.id)
       end
     end
   end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -80,10 +80,10 @@ RSpec.describe Invoice, type: :model do
   end
 
   describe 'Class Methods' do
-    describe '#incomplete_invoices' do
+    describe '#invoices_with_unshipped_items' do
       it 'will return all invoices that do not have a status of completed' do
 
-        expect(Invoice.incomplete_invoices).to eq([@invoice_1, @invoice_2, @invoice_3])
+        expect(Invoice.invoices_with_unshipped_items).to eq([@invoice_1, @invoice_2, @invoice_3])
 
       end
     end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -2,16 +2,90 @@ require 'rails_helper'
 
 RSpec.describe Invoice, type: :model do
   describe 'Validations' do
-    it {should validate_presence_of :status}
+    it { should validate_presence_of :status }
   end
 
   describe 'Relationships' do
-    it {should belong_to :customer}
-    it {should have_many :transactions}
+    it { should belong_to :customer }
+    it { should have_many :transactions }
+    it { should have_many :invoice_items }
+    it { should have_many(:items).through(:invoice_items) }
   end
 
   describe 'Enums' do
     xit 'enums tests' do
+    end
+  end
+
+  before(:each) do
+    @customers = create_list(:customer, 10)
+    @customer_1 = @customers[0]
+    @customer_2 = @customers[1]
+    @customer_3 = @customers[2]
+    @customer_4 = @customers[3]
+    @customer_5 = @customers[4]
+    @customer_6 = @customers[5]
+    @customer_7 = @customers[6]
+    @customer_8 = @customers[7]
+    @customer_9 = @customers[8]
+    @customer_10 = @customers[9]
+    @invoice_1 = @customer_1.invoices[0]
+    @invoice_2 = @customer_1.invoices[1]
+    @invoice_3 = @customer_1.invoices[2]
+    @invoice_4 = @customer_1.invoices[3]
+    @invoice_5 = @customer_1.invoices[4]
+    @invoice_6 = @customer_2.invoices[0]
+    @invoice_7 = @customer_2.invoices[1]
+    @invoice_8 = @customer_2.invoices[2]
+    @invoice_9 = @customer_2.invoices[3]
+    @invoice_10 = @customer_2.invoices[4]
+    @invoice_11 = @customer_3.invoices[0]
+    @invoice_12 = @customer_3.invoices[1]
+    @invoice_13 = @customer_3.invoices[2]
+    @invoice_14 = @customer_3.invoices[3]
+    @invoice_15 = @customer_3.invoices[4]
+    @invoice_16 = @customer_4.invoices[0]
+    @invoice_17 = @customer_4.invoices[1]
+    @invoice_18 = @customer_4.invoices[2]
+    @invoice_19 = @customer_4.invoices[3]
+    @invoice_20 = @customer_4.invoices[4]
+    @invoice_21 = @customer_5.invoices[0]
+    @invoice_22 = @customer_5.invoices[1]
+    @invoice_23 = @customer_5.invoices[2]
+    @invoice_24 = @customer_5.invoices[3]
+    @invoice_25 = @customer_5.invoices[4]
+
+    @merchants = create_list(:merchant, 10)
+    @merchant_1 = @merchants[0]
+    @merchant_2 = @merchants[1]
+    @merchant_3 = @merchants[2]
+    @merchant_4 = @merchants[3]
+    @merchant_5 = @merchants[4]
+    @merchant_6 = @merchants[5]
+    @merchant_7 = @merchants[6]
+    @merchant_8 = @merchants[7]
+    @merchant_9 = @merchants[8]
+    @merchant_10 = @merchants[9]
+    @item_1 = @merchant_1.items[0]
+    @item_2 = @merchant_1.items[1]
+    @item_3 = @merchant_1.items[2]
+    @item_4 = @merchant_1.items[3]
+    @item_5 = @merchant_1.items[4]
+
+    @invoice_item_1 = InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_1.id, quantity: 1, unit_price: 1300, status: 0)
+    @invoice_item_2 = InvoiceItem.create!(item_id: @item_2.id, invoice_id: @invoice_2.id, quantity: 1, unit_price: 1300, status: 0)
+    @invoice_item_3 = InvoiceItem.create!(item_id: @item_3.id, invoice_id: @invoice_3.id, quantity: 1, unit_price: 1300, status: 1)
+    @invoice_item_4 = InvoiceItem.create!(item_id: @item_4.id, invoice_id: @invoice_4.id, quantity: 1, unit_price: 1300, status: 2)
+    @invoice_item_5 = InvoiceItem.create!(item_id: @item_5.id, invoice_id: @invoice_5.id, quantity: 1, unit_price: 1300, status: 2)
+  end
+
+  describe 'Class Methods' do
+    describe '#incomplete_invoices' do
+      it 'will return all invoices that do not have a status of completed' do
+
+        expect(Invoice.incomplete_invoices).to eq([@invoice_1, @invoice_2, @invoice_3])
+
+      end
     end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -2,12 +2,13 @@ require 'rails_helper'
 
 RSpec.describe Item, type: :model do
   describe 'Validations' do
-    it {should validate_presence_of :name}
-    it {should validate_presence_of :description}
-    it {should validate_presence_of :unit_price}
+    it { should validate_presence_of :name }
+    it { should validate_presence_of :description }
+    it { should validate_presence_of :unit_price }
   end
 
   describe 'Relationships' do
-    it {should belong_to :merchant}
+    it { should belong_to :merchant }
+    it { should have_many :invoice_items }
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -2,11 +2,13 @@ require 'rails_helper'
 
 RSpec.describe Merchant, type: :model do
   describe 'Validations' do
-    it {should validate_presence_of :name}
+    it { should validate_presence_of :name }
   end
 
   describe 'Relationships' do
-    it {should have_many :items}
+    it { should have_many :items }
+    it { should have_many(:invoice_items).through(:items) }
+    it { should have_many(:invoices).through(:invoice_items) }
   end
 
   describe 'Enums' do


### PR DESCRIPTION
This branch adds the following functionality:
- Adds associations and tests for merchant and item models
- Adds after_create factory bot hooks to items and merchants factories
- Adds ability to see invoices with items that have not been shipped from admin dashboard view
   - It displays the invoice id number and the date that the invoice was created
   - It is set as a link to that specific invoices admin-invoice show page
- Adds class method for invoice model #invoices_with_unshipped_items

All tests currently passing

Resolves #19 