### PR TITLE
Admin merchants index status

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -27,6 +27,15 @@ class Admin::MerchantsController < ApplicationController
       end
     end
   end
+  
+  def new
+  end
+
+  def create
+    merchant = Merchant.new(admin_merchant_params)
+    merchant.save
+    redirect_to admin_merchants_path
+  end
 
   private
   def admin_merchant_params

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -14,15 +14,22 @@ class Admin::MerchantsController < ApplicationController
 
   def update
     merchant = Merchant.find(params[:id])
-    merchant.update(admin_merchant_params)
-    if merchant.save
-      redirect_to admin_merchant_path(merchant.id)
-      flash[:success] = "The information has been successfully updated for #{merchant.name}"
+
+    if params[:status].present?
+      merchant.update(admin_merchant_params)
+      merchant.save
+      redirect_to admin_merchants_path
+    else
+      merchant.update(admin_merchant_params)
+      if merchant.save
+        redirect_to admin_merchant_path(merchant.id)
+        flash[:success] = "The information has been successfully updated for #{merchant.name}"
+      end
     end
   end
 
   private
   def admin_merchant_params
-    params.permit(:name)
+    params.permit(:name, :status)
   end
 end

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -7,4 +7,22 @@ class Admin::MerchantsController < ApplicationController
   def show
     @merchant = Merchant.find(params[:id])
   end
+
+  def edit
+    @merchant = Merchant.find(params[:id])
+  end
+
+  def update
+    merchant = Merchant.find(params[:id])
+    merchant.update(admin_merchant_params)
+    if merchant.save
+      redirect_to admin_merchant_path(merchant.id)
+      flash[:success] = "The information has been successfully updated for #{merchant.name}"
+    end
+  end
+
+  private
+  def admin_merchant_params
+    params.permit(:name)
+  end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -9,7 +9,7 @@ class Merchant < ApplicationRecord
   has_many :transactions, through: :invoices
   has_many :customers, through: :invoices
 
-  enum status: ["enabled", "disabled"]
+  enum status: ["disabled", "enabled"]
 
   def top_five_cust
     self.transactions.joins(invoice: :customer) #what tables do we need
@@ -23,5 +23,9 @@ class Merchant < ApplicationRecord
   def not_shipped_invoices
     # require 'pry' ; binding.pry
     self.invoice_items.where("invoice_items.status != 2")
+  end
+
+  def enabled?
+    self.status == "enabled"
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,12 +1,15 @@
 class Merchant < ApplicationRecord
   
   validates :name, presence: true
+  validates :status, presence: true
 
   has_many :items, dependent: :destroy
   has_many :invoice_items, through: :items
   has_many :invoices, through: :invoice_items
   has_many :transactions, through: :invoices
   has_many :customers, through: :invoices
+
+  enum status: ["enabled", "disabled"]
 
   def top_five_cust
     self.transactions.joins(invoice: :customer) #what tables do we need

--- a/app/views/admin/merchants/edit.html.erb
+++ b/app/views/admin/merchants/edit.html.erb
@@ -1,0 +1,8 @@
+<h1>Update Merchant's Information</h1>
+
+<%= form_with url: admin_merchant_path(@merchant.id), method: :patch do |f| %>
+  <%= f.label :name, "Merchant's Name" %>
+  <%= f.text_field :name, value: @merchant.name %>
+
+  <%=f.submit "Submit" %>
+<% end %>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,4 +1,8 @@
-<h1>Admin Merchants Index</h1>
+<h1>Admin Dashboard</h1>
+
+<section class = "create_merchant">
+<%=  link_to 'New Merchant', new_admin_merchant_path %>
+</section>
 
 <section class = "merchants_info">
 
@@ -23,5 +27,5 @@
       <% end %>
     <% end %>
   </div>
-  
+
 </section>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,6 +1,8 @@
 <h1>Admin Merchants Index</h1>
 
 <section class = "merchants_info">
+
+  <h2>Enabled Merchants</h2>
   <div id="enabled_merchants">
     <% @merchants.each do |merchant| %>
       <% if merchant.enabled? %>
@@ -11,6 +13,7 @@
     <% end %>
   </div>
 
+  <h2>Disabled Merchants</h2>
   <div id="disabled_merchants">
     <% @merchants.each do |merchant| %>
       <% unless merchant.enabled? %>
@@ -20,4 +23,5 @@
       <% end %>
     <% end %>
   </div>
+  
 </section>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,7 +1,23 @@
 <h1>Admin Merchants Index</h1>
 
 <section class = "merchants_info">
-  <% @merchants.each do |merchant| %>
-    <%= link_to "#{merchant.name}", admin_merchant_path(merchant.id) %><br>
-  <% end %>
+  <div id="enabled_merchants">
+    <% @merchants.each do |merchant| %>
+      <% if merchant.enabled? %>
+        <div id="merchant_<%= merchant.id %>">
+          <%= link_to "#{merchant.name}", admin_merchant_path(merchant.id) %> <%= button_to "Disable", admin_merchant_path(merchant.id), method: :patch, params: {status: "disabled"} %><br>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+
+  <div id="disabled_merchants">
+    <% @merchants.each do |merchant| %>
+      <% unless merchant.enabled? %>
+        <div id="merchant_<%= merchant.id %>">
+          <%= link_to "#{merchant.name}", admin_merchant_path(merchant.id) %> <%= button_to "Enable", admin_merchant_path(merchant.id), method: :patch, params: {status: "enabled"} %><br>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
 </section>

--- a/app/views/admin/merchants/new.html.erb
+++ b/app/views/admin/merchants/new.html.erb
@@ -1,0 +1,6 @@
+<%= form_with url: admin_merchants_path, method: :post do |f| %>
+  <%= f.label :name, "Merchant's Name" %>
+  <%= f.text_field :name %>
+
+  <%=f.submit "Submit" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   resources :admin, only: :index
 
   namespace :admin do
-    resources :merchants, only: [:index, :show, :edit, :update]
+    resources :merchants, except: [:destroy]
   end
 
   resources :merchants do 

--- a/db/migrate/20240222223237_add_column_to_merchants.rb
+++ b/db/migrate/20240222223237_add_column_to_merchants.rb
@@ -1,0 +1,5 @@
+class AddColumnToMerchants < ActiveRecord::Migration[7.1]
+  def change
+    add_column :merchants, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_20_220145) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_22_223237) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -55,6 +55,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_20_220145) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0
   end
 
   create_table "transactions", force: :cascade do |t|

--- a/spec/factories/merchants.rb
+++ b/spec/factories/merchants.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :merchant do
     name { Faker::Company.name }
+    status { 0 }
 
     # after :create do |merchant|
     #   create_list :item, 5, merchant: merchant

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Adminn Merchants Index', type: :feature do
+RSpec.describe 'Admin Merchants Index', type: :feature do
   describe 'As an admin' do
     before(:each) do
       @customer_1 = create(:customer)
@@ -36,10 +36,10 @@ RSpec.describe 'Adminn Merchants Index', type: :feature do
       @trans_14 = create(:transaction, invoice_id: @invoice_4.id)
       @trans_15 = create(:transaction, invoice_id: @invoice_5.id)
       
-      @merchant_1 = create(:merchant, name: "Amazon") 
-      @merchant_2 = create(:merchant, name: "Walmart") 
-      @merchant_3 = create(:merchant, name: "Apple") 
-      @merchant_4 = create(:merchant, name: "Microsoft") 
+      @merchant_1 = create(:merchant, name: "Amazon", status: 0) 
+      @merchant_2 = create(:merchant, name: "Walmart", status: 0) 
+      @merchant_3 = create(:merchant, name: "Apple", status: 0) 
+      @merchant_4 = create(:merchant, name: "Microsoft", status: 0) 
 
       @item_1 = create(:item, unit_price: 1, merchant_id: @merchant_1.id)
       @item_2 = create(:item, unit_price: 1, merchant_id: @merchant_1.id)
@@ -86,7 +86,7 @@ RSpec.describe 'Adminn Merchants Index', type: :feature do
           within "#merchant_#{@merchant_3.id}" do
             expect(page).to have_button("Enable")
             # When I click this button
-            click "Enable"
+            click_on "Enable"
           end
         end
         within "#enabled_merchants" do

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -132,15 +132,12 @@ RSpec.describe 'Admin Merchants Index', type: :feature do
       # As an admin, when I visit the admin merchants index (/admin/merchants)
       visit admin_merchants_path
       # I see a link to create a new merchant.
-      expect(page).to have_link("Create New Merchant", :href=>new_admin_merchant_path)
+      expect(page).to have_link("New Merchant", :href=>new_admin_merchant_path)
       # When I click on the link,
-      click_link "Create New Merchant"
+      click_link "New Merchant"
       # I am taken to a form that allows me to add merchant information.
       expect(current_path).to eq(new_admin_merchant_path)
-      # When I fill out the form I click ‘Submit’
-      # Then I am taken back to the admin merchants index page
-      # And I see the merchant I just created displayed
-      # And I see my merchant was created with a default status of disabled.
+      # Continued in spec/features/admin/merchants/new_spec.rb
     end
   end
 end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -40,6 +40,9 @@ RSpec.describe 'Admin Merchants Index', type: :feature do
       @merchant_2 = create(:merchant, name: "Walmart", status: 0) 
       @merchant_3 = create(:merchant, name: "Apple", status: 0) 
       @merchant_4 = create(:merchant, name: "Microsoft", status: 0) 
+      @merchant_5 = create(:merchant, name: "Petco", status: 1) 
+      @merchant_6 = create(:merchant, name: "Aetna", status: 1) 
+      @merchant_7 = create(:merchant, name: "Adidas", status: 1) 
 
       @item_1 = create(:item, unit_price: 1, merchant_id: @merchant_1.id)
       @item_2 = create(:item, unit_price: 1, merchant_id: @merchant_1.id)
@@ -97,6 +100,30 @@ RSpec.describe 'Admin Merchants Index', type: :feature do
             expect(page).to have_button("Disable")
           end
         end
+      end
+    end
+
+    # User story 28. Admin Merchants Grouped by Status
+    it 'shows two separate sections for enabled and disabled merchants and shows the correct merchant names in each section' do
+      # As an admin, when I visit the admin merchants index (/admin/merchants)
+      visit admin_merchants_path
+      
+      # Then I see two sections, one for "Enabled Merchants" and one for "Disabled Merchants"
+      expect(page).to have_content("Enabled Merchants")
+      expect(page).to have_content("Disabled Merchants")
+      
+      # And I see that each Merchant is listed in the appropriate section
+      within "#enabled_merchants" do
+        expect(page).to have_content(@merchant_5.name)
+        expect(page).to have_content(@merchant_6.name)
+        expect(page).to have_content(@merchant_7.name)
+      end
+
+      within "#disabled_merchants" do
+        expect(page).to have_content(@merchant_1.name)
+        expect(page).to have_content(@merchant_2.name)
+        expect(page).to have_content(@merchant_3.name)
+        expect(page).to have_content(@merchant_4.name)
       end
     end
   end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -1,73 +1,103 @@
 require 'rails_helper'
 
 RSpec.describe 'Adminn Merchants Index', type: :feature do
- describe 'As an admin' do
-  before(:each) do
-    @customer_1 = create(:customer)
-    @customer_2 = create(:customer)
-    @customer_3 = create(:customer)
-    @customer_4 = create(:customer)
-    @customer_5 = create(:customer)
-    @customer_6 = create(:customer)
+  describe 'As an admin' do
+    before(:each) do
+      @customer_1 = create(:customer)
+      @customer_2 = create(:customer)
+      @customer_3 = create(:customer)
+      @customer_4 = create(:customer)
+      @customer_5 = create(:customer)
+      @customer_6 = create(:customer)
 
-    @invoice_1 = create(:invoice, customer_id: @customer_1.id)
-    @invoice_2 = create(:invoice, customer_id: @customer_2.id)
-    @invoice_3 = create(:invoice, customer_id: @customer_3.id)
-    @invoice_4 = create(:invoice, customer_id: @customer_4.id)
-    @invoice_5 = create(:invoice, customer_id: @customer_5.id)
-    @invoice_6 = create(:invoice, customer_id: @customer_6.id)
-    @invoice_7 = create(:invoice, customer_id: @customer_5.id, status: 0, created_at: "Wed, 21 Feb 2024 00:47:11.096539000 UTC +00:00")
-    @invoice_8 = create(:invoice, customer_id: @customer_5.id, status: 0, created_at: "Tues, 20 Feb 2024 00:47:11.096539000 UTC +00:00")
-    @invoice_9 = create(:invoice, customer_id: @customer_5.id, status: 0, created_at: "Mon, 19 Feb 2024 00:47:11.096539000 UTC +00:00")
+      @invoice_1 = create(:invoice, customer_id: @customer_1.id)
+      @invoice_2 = create(:invoice, customer_id: @customer_2.id)
+      @invoice_3 = create(:invoice, customer_id: @customer_3.id)
+      @invoice_4 = create(:invoice, customer_id: @customer_4.id)
+      @invoice_5 = create(:invoice, customer_id: @customer_5.id)
+      @invoice_6 = create(:invoice, customer_id: @customer_6.id)
+      @invoice_7 = create(:invoice, customer_id: @customer_5.id, status: 0, created_at: "Wed, 21 Feb 2024 00:47:11.096539000 UTC +00:00")
+      @invoice_8 = create(:invoice, customer_id: @customer_5.id, status: 0, created_at: "Tues, 20 Feb 2024 00:47:11.096539000 UTC +00:00")
+      @invoice_9 = create(:invoice, customer_id: @customer_5.id, status: 0, created_at: "Mon, 19 Feb 2024 00:47:11.096539000 UTC +00:00")
 
-    @trans_1 = create(:transaction, invoice_id: @invoice_1.id)
-    @trans_2 = create(:transaction, invoice_id: @invoice_1.id)
-    @trans_3 = create(:transaction, invoice_id: @invoice_1.id)
-    @trans_4 = create(:transaction, invoice_id: @invoice_1.id)
-    @trans_5 = create(:transaction, invoice_id: @invoice_1.id)
-    @trans_6 = create(:transaction, invoice_id: @invoice_2.id)
-    @trans_7 = create(:transaction, invoice_id: @invoice_2.id)
-    @trans_8 = create(:transaction, invoice_id: @invoice_2.id)
-    @trans_9 = create(:transaction, invoice_id: @invoice_2.id)
-    @trans_10 = create(:transaction, invoice_id: @invoice_3.id)
-    @trans_11 = create(:transaction, invoice_id: @invoice_3.id)
-    @trans_12 = create(:transaction, invoice_id: @invoice_3.id)
-    @trans_13 = create(:transaction, invoice_id: @invoice_4.id)
-    @trans_14 = create(:transaction, invoice_id: @invoice_4.id)
-    @trans_15 = create(:transaction, invoice_id: @invoice_5.id)
-    
-    @merchant_1 = create(:merchant, name: "Amazon") 
-    @merchant_4 = create(:merchant, name: "Walmart") 
-    @merchant_5 = create(:merchant, name: "Apple") 
-    @merchant_6 = create(:merchant, name: "Microsoft") 
+      @trans_1 = create(:transaction, invoice_id: @invoice_1.id)
+      @trans_2 = create(:transaction, invoice_id: @invoice_1.id)
+      @trans_3 = create(:transaction, invoice_id: @invoice_1.id)
+      @trans_4 = create(:transaction, invoice_id: @invoice_1.id)
+      @trans_5 = create(:transaction, invoice_id: @invoice_1.id)
+      @trans_6 = create(:transaction, invoice_id: @invoice_2.id)
+      @trans_7 = create(:transaction, invoice_id: @invoice_2.id)
+      @trans_8 = create(:transaction, invoice_id: @invoice_2.id)
+      @trans_9 = create(:transaction, invoice_id: @invoice_2.id)
+      @trans_10 = create(:transaction, invoice_id: @invoice_3.id)
+      @trans_11 = create(:transaction, invoice_id: @invoice_3.id)
+      @trans_12 = create(:transaction, invoice_id: @invoice_3.id)
+      @trans_13 = create(:transaction, invoice_id: @invoice_4.id)
+      @trans_14 = create(:transaction, invoice_id: @invoice_4.id)
+      @trans_15 = create(:transaction, invoice_id: @invoice_5.id)
+      
+      @merchant_1 = create(:merchant, name: "Amazon") 
+      @merchant_2 = create(:merchant, name: "Walmart") 
+      @merchant_3 = create(:merchant, name: "Apple") 
+      @merchant_4 = create(:merchant, name: "Microsoft") 
 
-    @item_1 = create(:item, unit_price: 1, merchant_id: @merchant_1.id)
-    @item_2 = create(:item, unit_price: 1, merchant_id: @merchant_1.id)
-    @item_3 = create(:item, unit_price: 1, merchant_id: @merchant_1.id)
-    @item_4 = create(:item, unit_price: 1, merchant_id: @merchant_1.id)
-    @item_5 = create(:item, unit_price: 1, merchant_id: @merchant_1.id)
+      @item_1 = create(:item, unit_price: 1, merchant_id: @merchant_1.id)
+      @item_2 = create(:item, unit_price: 1, merchant_id: @merchant_1.id)
+      @item_3 = create(:item, unit_price: 1, merchant_id: @merchant_1.id)
+      @item_4 = create(:item, unit_price: 1, merchant_id: @merchant_1.id)
+      @item_5 = create(:item, unit_price: 1, merchant_id: @merchant_1.id)
 
-    @invoice_item_1 = create(:invoice_item, item_id: @item_1.id, invoice_id: @invoice_1.id, quantity: 1, unit_price: 1300, status: 0)
-    @invoice_item_2 = create(:invoice_item, item_id: @item_2.id, invoice_id: @invoice_2.id, quantity: 1, unit_price: 1300, status: 0)
-    @invoice_item_3 = create(:invoice_item, item_id: @item_3.id, invoice_id: @invoice_3.id, quantity: 1, unit_price: 1300, status: 1)
-    @invoice_item_4 = create(:invoice_item, item_id: @item_4.id, invoice_id: @invoice_4.id, quantity: 1, unit_price: 1300, status: 2)
-    @invoice_item_5 = create(:invoice_item, item_id: @item_5.id, invoice_id: @invoice_5.id, quantity: 1, unit_price: 1300, status: 2)
-    @invoice_item_6 = create(:invoice_item, item_id: @item_5.id, invoice_id: @invoice_7.id, quantity: 1, unit_price: 1300, status: 0)
-    @invoice_item_7 = create(:invoice_item, item_id: @item_5.id, invoice_id: @invoice_8.id, quantity: 1, unit_price: 1300, status: 0)
-    @invoice_item_8 = create(:invoice_item, item_id: @item_5.id, invoice_id: @invoice_9.id, quantity: 1, unit_price: 1300, status: 0)
-  end
+      @invoice_item_1 = create(:invoice_item, item_id: @item_1.id, invoice_id: @invoice_1.id, quantity: 1, unit_price: 1300, status: 0)
+      @invoice_item_2 = create(:invoice_item, item_id: @item_2.id, invoice_id: @invoice_2.id, quantity: 1, unit_price: 1300, status: 0)
+      @invoice_item_3 = create(:invoice_item, item_id: @item_3.id, invoice_id: @invoice_3.id, quantity: 1, unit_price: 1300, status: 1)
+      @invoice_item_4 = create(:invoice_item, item_id: @item_4.id, invoice_id: @invoice_4.id, quantity: 1, unit_price: 1300, status: 2)
+      @invoice_item_5 = create(:invoice_item, item_id: @item_5.id, invoice_id: @invoice_5.id, quantity: 1, unit_price: 1300, status: 2)
+      @invoice_item_6 = create(:invoice_item, item_id: @item_5.id, invoice_id: @invoice_7.id, quantity: 1, unit_price: 1300, status: 0)
+      @invoice_item_7 = create(:invoice_item, item_id: @item_5.id, invoice_id: @invoice_8.id, quantity: 1, unit_price: 1300, status: 0)
+      @invoice_item_8 = create(:invoice_item, item_id: @item_5.id, invoice_id: @invoice_9.id, quantity: 1, unit_price: 1300, status: 0)
+    end
 
-  #User Story 24. Admin Merchants Index
-  it 'displays the name of each merchant in the system' do
-    # As an admin, When I visit the admin merchants index (/admin/merchants)
-    visit admin_merchants_path
-    # Then I see the name of each merchant in the system
-    within ".merchants_info" do
-      expect(page).to have_content("Amazon")
-      expect(page).to have_content("Walmart")
-      expect(page).to have_content("Apple")
-      expect(page).to have_content("Microsoft")
+    #User Story 24. Admin Merchants Index
+    it 'displays the name of each merchant in the system' do
+      # As an admin, When I visit the admin merchants index (/admin/merchants)
+      visit admin_merchants_path
+      # Then I see the name of each merchant in the system
+      within ".merchants_info" do
+        expect(page).to have_content("Amazon")
+        expect(page).to have_content("Walmart")
+        expect(page).to have_content("Apple")
+        expect(page).to have_content("Microsoft")
+      end
+    end
+
+    # User Story 27. Admin Merchant Enable/Disable
+    it 'displays a button to enable or disable a merchant and when clicked it will change the merchants status and return to the index page with the merchant in its new section' do
+      # As an admin, when I visit the admin merchants index (/admin/merchants)
+      visit admin_merchants_path
+      # Then next to each merchant name I see a button to disable or enable that merchant.
+      within ".merchants_info" do
+        within "#disabled_merchants" do
+          within "#merchant_#{@merchant_1.id}" do
+            expect(page).to have_button("Enable")
+          end
+          within "#merchant_#{@merchant_2.id}" do
+            expect(page).to have_button("Enable")
+          end
+          within "#merchant_#{@merchant_3.id}" do
+            expect(page).to have_button("Enable")
+            # When I click this button
+            click "Enable"
+          end
+        end
+        within "#enabled_merchants" do
+          within "#merchant_#{@merchant_3.id}" do
+            # Then I am redirected back to the admin merchants index
+            expect(current_path).to eq(admin_merchants_path)
+            # And I see that the merchant's status has changed
+            expect(page).to have_button("Disable")
+          end
+        end
+      end
     end
   end
- end
 end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -126,5 +126,21 @@ RSpec.describe 'Admin Merchants Index', type: :feature do
         expect(page).to have_content(@merchant_4.name)
       end
     end
+
+    # User story 29. Admin Merchant Create
+    it 'shows a link to create a new merchant on the admin merchant index page' do
+      # As an admin, when I visit the admin merchants index (/admin/merchants)
+      visit admin_merchants_path
+      # I see a link to create a new merchant.
+      expect(page).to have_link("Create New Merchant", :href=>new_admin_merchant_path)
+      # When I click on the link,
+      click_link "Create New Merchant"
+      # I am taken to a form that allows me to add merchant information.
+      expect(current_path).to eq(new_admin_merchant_path)
+      # When I fill out the form I click ‘Submit’
+      # Then I am taken back to the admin merchants index page
+      # And I see the merchant I just created displayed
+      # And I see my merchant was created with a default status of disabled.
+    end
   end
 end

--- a/spec/features/admin/merchants/new_spec.rb
+++ b/spec/features/admin/merchants/new_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin Merchants New Page', type: :feature do
+  describe 'As an admin' do
+    before(:each) do
+      
+    end
+    # User story 29. Admin Merchant Create continued
+    it 'shows a form to create a new merchant with a default status, and returns to the admin merchants index page where it is displayed with the entered info and default status' do
+      visit new_admin_merchant_path
+
+      expect(page).to have_field("name")
+      # When I fill out the form I click ‘Submit’
+      fill_in "name", with: "Nike"
+      click_on "Submit"
+      # Then I am taken back to the admin merchants index page
+      expect(current_path).to eq(admin_merchants_path)
+      # And I see the merchant I just created displayed
+      # And I see my merchant was created with a default status of disabled.
+      within "#disabled_merchants" do
+        expect(page).to have_content("Nike")
+      end
+    end
+  end
+end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -63,5 +63,17 @@ RSpec.describe Merchant, type: :model do
     it "#not_shipped_invoices" do
       expect(@merch_1.not_shipped_invoices).to eq(@invoice_6.invoice_items)
     end
+
+    describe '#enabled?' do
+      it 'returns true or false depending on the status' do
+        merch_1 = create(:merchant, name: "Amazon", status: 0)
+
+        expect(merch_1.enabled?).to eq(false)
+
+        merch_2 = create(:merchant, name: "Petco", status: 1) 
+
+        expect(merch_2.enabled?).to eq(true)
+      end
+    end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe Merchant, type: :model do
 
   describe 'Validations' do
     it { should validate_presence_of :name }
+    it { should validate_presence_of :status }
   end
 
   describe 'Relationships' do


### PR DESCRIPTION
This branch adds the following:
- Adds a migration to update the merchants table to include a column for status with options of enabled and disabled, set up as an enum, default value is set to disabled
- Adds status attribute to factorybot file
- Adds #enabled? to merchant model
- Adds the ability to enable or disable merchants from the admin merchants index page
   - Merchants are displayed in two separate section based on their status
   - Buttons to change that status are displayed next to their names
   - Buttons go to admin/merchants_controller with params to change the status, update now has conditions on how it updates/redirects based on those params
- Adds link to create new merchants from admin merchants index page
- Adds new and create actions to admin/merchants_controller

All tests are passing