### PR TITLE
Admin invoice show page

### DIFF
--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -7,4 +7,17 @@ class Admin::InvoicesController < ApplicationController
   def show
     @invoice = Invoice.find(params[:id])
   end
+
+  def update
+    invoice = Invoice.find(params[:id])
+
+    invoice.update(status: strong_params[:status].to_i)
+
+    redirect_to admin_invoice_path(invoice)
+  end
+
+  private
+  def strong_params
+    params.permit(:id, :status)
+  end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -21,4 +21,8 @@ class Invoice < ApplicationRecord
   def self.invoices_with_unshipped_items_oldest_to_newest
     Invoice.invoices_with_unshipped_items.oldest_to_newest
   end
+
+  def total_revenue
+    invoice_items.sum("quantity * unit_price")/100.00
+  end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -22,7 +22,7 @@ class Invoice < ApplicationRecord
     Invoice.invoices_with_unshipped_items.oldest_to_newest
   end
 
-  def total_revenue
+  def total_revenue_dollars
     invoice_items.sum("quantity * unit_price")/100.00
   end
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -10,4 +10,8 @@ class InvoiceItem < ApplicationRecord
   # has_many :merchants, through: :items
   
   enum status: ["pending", "packaged", "shipped"]
+
+  def unit_price_to_dollars
+    unit_price/100.00
+  end
 end

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -2,3 +2,15 @@
 <p>Status: <%= @invoice.status %></p>
 <p>Created on: <%= @invoice.created_at.strftime('%A, %B %d, %Y') %></p>
 <p>Customer: <%= @invoice.customer.first_name %> <%= @invoice.customer.last_name %></p>
+
+<section class="invoice_items">
+  <h3>Items on this invoice</h3>
+  <% @invoice.invoice_items.each do |invoice_item| %>
+    <div id="invoice_item-<%= invoice_item.id%>">
+      <%= invoice_item.item.name %>
+      <%= invoice_item.quantity %>
+      <%= invoice_item.unit_price %>
+      <%= invoice_item.status %>
+    </div>
+  <% end %>
+</section>

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -1,5 +1,12 @@
 <h1>Invoice #<%= @invoice.id %></h1>
-<p>Status: <%= @invoice.status %></p>
+
+<div id="invoice_status">
+  <%= form_with url: admin_invoice_path(@invoice), method: :patch, data: {turbo: false} do |f| %>
+    Status: <%= f.select "status", options_for_select([["In Progress", 0], ["Cancelled", 1], ["Completed", 2]]), value: @invoice.status%>
+    <%= f.button "Update Invoice" %>
+  <% end %>
+</div>
+
 <p>Created on: <%= @invoice.created_at.strftime('%A, %B %d, %Y') %></p>
 
 <div id="invoice_revenue">

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -1,6 +1,11 @@
 <h1>Invoice #<%= @invoice.id %></h1>
 <p>Status: <%= @invoice.status %></p>
 <p>Created on: <%= @invoice.created_at.strftime('%A, %B %d, %Y') %></p>
+
+<div id="invoice_revenue">
+  <p>Total Revenue: <%= number_to_currency((@invoice.total_revenue), unit: "$")%></p>
+</div>
+
 <p>Customer: <%= @invoice.customer.first_name %> <%= @invoice.customer.last_name %></p>
 
 <section class="invoice_items">
@@ -9,7 +14,7 @@
     <div id="invoice_item-<%= invoice_item.id%>">
       <%= invoice_item.item.name %>
       <%= invoice_item.quantity %>
-      <%= invoice_item.unit_price %>
+      <%= number_to_currency((invoice_item.unit_price_to_dollars), unit: "$") %>
       <%= invoice_item.status %>
     </div>
   <% end %>

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -10,7 +10,7 @@
 <p>Created on: <%= @invoice.created_at.strftime('%A, %B %d, %Y') %></p>
 
 <div id="invoice_revenue">
-  <p>Total Revenue: <%= number_to_currency((@invoice.total_revenue), unit: "$")%></p>
+  <p>Total Revenue: <%= number_to_currency((@invoice.total_revenue_dollars), unit: "$")%></p>
 </div>
 
 <p>Customer: <%= @invoice.customer.first_name %> <%= @invoice.customer.last_name %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   resources :admin, only: :index
 
   namespace :admin do
-    resources :invoices, only: [:index, :show]
+    resources :invoices, only: [:index, :show, :update]
   end
 
   namespace :admin do

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe 'Admin Index Show', type: :feature do
       @invoice_item_6 = create(:invoice_item, item_id: @item_6.id, invoice_id: @invoice_7.id, quantity: 1, unit_price: 78000, status: 0)
       @invoice_item_7 = create(:invoice_item, item_id: @item_7.id, invoice_id: @invoice_8.id, quantity: 1, unit_price: 78000, status: 0)
       @invoice_item_8 = create(:invoice_item, item_id: @item_8.id, invoice_id: @invoice_9.id, quantity: 4, unit_price: 5500, status: 0)
+      @invoice_item_9 = create(:invoice_item, item_id: @item_8.id, invoice_id: @invoice_1.id, quantity: 4, unit_price: 5500, status: 2)
     end
 
     # User story 33. Admin Invoice Show Page
@@ -83,6 +84,35 @@ RSpec.describe 'Admin Index Show', type: :feature do
       expect(page).to have_content("Created on: Wednesday, February 21, 2024")
       # Customer first and last name
       expect(page).to have_content("Customer: #{@customer_1.first_name} #{@customer_1.last_name}")
+    end
+
+    # User Story 34. Admin Invoice Show Page: Invoice Item Information
+    it "displays all of the items on the invoice, with name, quantity and price, and Invoice item status" do
+      # As an admin, When I visit an admin invoice show page (/admin/invoices/:invoice_id)
+      visit admin_invoice_path(@invoice_1.id)
+      # Then I see all of the items on the invoice including:
+      expect(page).to have_content("Items on this invoice")
+      within "#invoice_item-#{@invoice_item_1.id}" do
+        # Item name
+        expect(page).to have_content(@item_1.name)
+        # The quantity of the item ordered
+        expect(page).to have_content(@invoice_item_1.quantity)
+        # The price the Item sold for
+        expect(page).to have_content(@invoice_item_1.unit_price)
+        # The Invoice Item status
+        expect(page).to have_content(@invoice_item_1.status)
+      end
+
+      within "#invoice_item-#{@invoice_item_9.id}" do
+        # Item name
+        expect(page).to have_content(@item_8.name)
+        # The quantity of the item ordered
+        expect(page).to have_content(@invoice_item_9.quantity)
+        # The price the Item sold for
+        expect(page).to have_content(@invoice_item_9.unit_price)
+        # The Invoice Item status
+        expect(page).to have_content(@invoice_item_9.status)
+      end
     end
   end
 end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe 'Admin Index Show', type: :feature do
         # The quantity of the item ordered
         expect(page).to have_content(@invoice_item_1.quantity)
         # The price the Item sold for
-        expect(page).to have_content(@invoice_item_1.unit_price)
+        expect(page).to have_content(@invoice_item_1.unit_price_to_dollars)
         # The Invoice Item status
         expect(page).to have_content(@invoice_item_1.status)
       end
@@ -109,9 +109,19 @@ RSpec.describe 'Admin Index Show', type: :feature do
         # The quantity of the item ordered
         expect(page).to have_content(@invoice_item_9.quantity)
         # The price the Item sold for
-        expect(page).to have_content(@invoice_item_9.unit_price)
+        expect(page).to have_content(@invoice_item_9.unit_price_to_dollars)
         # The Invoice Item status
         expect(page).to have_content(@invoice_item_9.status)
+      end
+    end
+
+    # User Story 35. Admin Invoice Show Page: Total Revenue
+    it "displays the total revenue that will be generated from this invoice" do
+      # As an admin, When I visit an admin invoice show page (/admin/invoices/:invoice_id)
+      visit admin_invoice_path(@invoice_1)
+      # Then I see the total revenue that will be generated from this invoice.
+      within "#invoice_revenue" do
+        expect(page).to have_content("Total Revenue: $233.00")
       end
     end
   end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe 'Admin Index Show', type: :feature do
       # Invoice id
       expect(page).to have_content("Invoice ##{@invoice_1.id}")
       # Invoice status
-      expect(page).to have_content("Status: #{@invoice_1.status}")
+      expect(page).to have_content("Status: In Progress")
       # Invoice created_at date in the format "Monday, July 18, 2019"
       expect(page).to have_content("Created on: Wednesday, February 21, 2024")
       # Customer first and last name
@@ -122,6 +122,30 @@ RSpec.describe 'Admin Index Show', type: :feature do
       # Then I see the total revenue that will be generated from this invoice.
       within "#invoice_revenue" do
         expect(page).to have_content("Total Revenue: $233.00")
+      end
+    end
+
+    #User Story 36. Admin Invoice Show Page: Update Invoice Status
+    it "displays a select field for" do
+      # As an admin, When I visit an admin invoice show page (/admin/invoices/:invoice_id)
+      visit admin_invoice_path(@invoice_1)
+
+      within "#invoice_status" do
+        # I see the invoice status is a select field
+        expect(page).to have_select("status")
+        # And I see that the invoice's current status is selected
+        expect(page).to have_content("In Progress")
+        # When I click this select field,
+        expect(page).to have_select("status", with_options: ["In Progress", "Cancelled", "Completed"])
+        # Then I can select a new status for the Invoice,
+        select("Cancelled", from: "status")
+        # And next to the select field I see a button to "Update Invoice Status"
+        # When I click this button
+        click_button("Update Invoice")
+        # I am taken back to the admin invoice show page
+        expect(current_path).to eq(admin_invoice_path(@invoice_1))
+        # And I see that my Invoice's status has now been updated
+        expect(page).to have_content("Cancelled")
       end
     end
   end

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -61,8 +61,12 @@ RSpec.describe 'Admin Merchants Show', type: :feature do
   it 'displays merchants name' do
     # As an admin, When I click on the name of a merchant from the admin merchants index page (/admin/merchants),
     visit admin_merchants_path
-    click_link("Amazon")
-    # Then I am taken to that merchant's admin show page (/admin/merchants/:merchant_id)
+    within "#disabled_merchants" do
+      within "#merchant_#{@merchant_1.id}" do
+        click_link("Amazon")
+        # Then I am taken to that merchant's admin show page (/admin/merchants/:merchant_id)
+      end
+    end
     expect(current_path).to eq(admin_merchant_path(@merchant_1.id))
     # And I see the name of that merchant    
     expect(page).to have_content("Amazon")

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -16,4 +16,29 @@ RSpec.describe InvoiceItem, type: :model do
     xit "enum tests" do
     end
   end
+
+  before do
+    @customer_1 = create(:customer)
+    @customer_2 = create(:customer)
+
+    @invoice_1 = create(:invoice, customer_id: @customer_1.id, created_at: "Wed, 21 Feb 2024 00:47:11.096539000 UTC +00:00")
+    @invoice_2 = create(:invoice, customer_id: @customer_2.id, created_at: "Wed, 21 Feb 2024 00:47:11.096539000 UTC +00:00")
+
+    @merchant_1 = create(:merchant, name: "Amazon", status: 0)
+
+    @item_1 = create(:item, unit_price: 1, merchant_id: @merchant_1.id)
+    @item_2 = create(:item, unit_price: 1, merchant_id: @merchant_1.id)
+
+    @invoice_item_1 = create(:invoice_item, item_id: @item_1.id, invoice_id: @invoice_1.id, quantity: 1, unit_price: 1300, status: 0)
+    @invoice_item_2 = create(:invoice_item, item_id: @item_2.id, invoice_id: @invoice_2.id, quantity: 3, unit_price: 2534, status: 0)
+  end
+
+  describe "Instance Methods" do
+    describe "#unit_price_to_dollars" do
+      it "returns the unit price converted to dollars" do
+        expect(@invoice_item_1.unit_price_to_dollars).to eq(13.00)
+        expect(@invoice_item_2.unit_price_to_dollars).to eq(25.34)
+      end
+    end
+  end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -98,10 +98,10 @@ RSpec.describe Invoice, type: :model do
   end
 
   describe "#Instance Methods" do
-    describe "#total_revenue" do
+    describe "#total_revenue_dollars" do
       it "returns the correct revenue that an invoice will generate" do
-        expect(@invoice_1.total_revenue).to eq(233.00)
-        expect(@invoice_2.total_revenue).to eq(13.00)
+        expect(@invoice_1.total_revenue_dollars).to eq(233.00)
+        expect(@invoice_2.total_revenue_dollars).to eq(13.00)
       end
     end
   end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe Invoice, type: :model do
     @invoice_item_6 = create(:invoice_item, item_id: @item_5.id, invoice_id: @invoice_7.id, quantity: 1, unit_price: 1300, status: 0)
     @invoice_item_7 = create(:invoice_item, item_id: @item_5.id, invoice_id: @invoice_8.id, quantity: 1, unit_price: 1300, status: 0)
     @invoice_item_8 = create(:invoice_item, item_id: @item_5.id, invoice_id: @invoice_9.id, quantity: 1, unit_price: 1300, status: 0)
+    @invoice_item_9 = create(:invoice_item, item_id: @item_5.id, invoice_id: @invoice_1.id, quantity: 4, unit_price: 5500, status: 2)
   end
 
   describe 'Class Methods' do
@@ -92,6 +93,15 @@ RSpec.describe Invoice, type: :model do
       it 'will return the invoices with the oldest created at dates first if they have unshipped items' do
 
         expect(Invoice.invoices_with_unshipped_items_oldest_to_newest).to eq([@invoice_9, @invoice_8, @invoice_7, @invoice_1, @invoice_2, @invoice_3])
+      end
+    end
+  end
+
+  describe "#Instance Methods" do
+    describe "#total_revenue" do
+      it "returns the correct revenue that an invoice will generate" do
+        expect(@invoice_1.total_revenue).to eq(233.00)
+        expect(@invoice_2.total_revenue).to eq(13.00)
       end
     end
   end


### PR DESCRIPTION
This branch updates:
- Fix failing test for user story 25, modifying the spec file spec/features/admin/merchants/show_spec.rb so it looks for merchants name in the intended section of the view.
- Builds from existing functionality for admin invoice show page to close user stories 34 to 36.